### PR TITLE
feat: defaultExpandDepth

### DIFF
--- a/projects/ngx-json-schema-viewer/src/lib/services/jsv-options.ts
+++ b/projects/ngx-json-schema-viewer/src/lib/services/jsv-options.ts
@@ -34,6 +34,16 @@ export type JSVOptions = {
      * @default ["nullable","deprecated","readOnly","writeOnly","enum","stringLength","objectProperties","no-extra-properties","arrayItems","arrayContains","no-extra-items","number-range","pattern","multipleOf","uniqueItems","contentEncoding","contentMediaType","contentSchema","default","const","examples"]
      */
     qualifierMessagesOrder: CheckKey[]
+    /**
+     * Defines how deep the schema should be expanded by default
+     * Examples:
+     *  - 0: only the root level is expanded
+     *  - 1: root level and its direct children are expanded
+     *  - Infinity: expand all levels
+     * @default 0
+     * @min 0
+     */
+    defaultExpandDepth: number
 }
 
 // Define an InjectionToken for JSVOptions
@@ -72,7 +82,8 @@ export class JSVOptionsService {
                 "default",
                 "const",
                 "examples"
-            ]
+            ],
+            defaultExpandDepth: 0
         }
         // Apply user provided options
         this.setOptions(userOptions);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control the default expansion depth of JSON Schemas. Set how many levels expand on load (0 = root only, 1 = root + direct children, Infinity = all levels). Defaults to root only; behavior remains unchanged unless configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->